### PR TITLE
Add Solarized Light theme for GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ ridehome.db-journal
 __pycache__/
 .claude
 trash
+
+# Jekyll build artifacts
+docs/_site/
+docs/.jekyll-cache/
+docs/Gemfile.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- **Solarized Light theme for GitHub Pages** - Custom visual design replacing default Jekyll styling
+  - **Base theme:** minima (clean, technical foundation)
+  - **Color scheme:** Solarized Light palette for readability and technical aesthetic
+    - Background: Warm off-white (#fdf6e3)
+    - Text: Muted gray-blue (#657b83)
+    - Links: Blue (#268bd2) with distinct visited state (violet #6c71c4)
+    - Accent colors: Full Solarized palette for code, tables, emphasis
+  - **Typography:** System font stack for performance, generous line-height (1.6-1.8) for readability
+  - **Link-focused design:** Clear visual hierarchy, underlines with transparency, hover states
+  - **Table styling:** Clean borders and alternating rows for Wrapped stats pages
+  - **Configuration:**
+    - `docs/_config.yml` - Jekyll theme configuration
+    - `docs/assets/css/style.scss` - Complete Solarized Light stylesheet
+    - `docs/Gemfile` - Local development dependencies
+  - **Benefits:** Distinctive identity, improved readability, maintains focus on links content
+  - **No animations or images** - Clean, technical presentation
+
 ## [1.2.1] - 2025-12-21
 
 ### Changed

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,2 @@
+source "https://rubygems.org"
+gem "github-pages", group: :jekyll_plugins

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,13 @@
+# Site settings
+title: The Ride Home - Link Archive
+description: Daily tech news links from The Ride Home podcast
+
+# Build settings
+theme: minima
+
+# Minima theme customization
+minima:
+  date_format: "%b %-d, %Y"
+
+# Solarized Light color scheme
+# Base: clean, technical, readable

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,0 +1,241 @@
+---
+---
+
+@import "{{ site.theme }}";
+
+/**
+ * Solarized Light Theme
+ * Clean, technical, readable - focus on the links
+ */
+
+/* Solarized Light Color Palette */
+$base03:    #002b36;
+$base02:    #073642;
+$base01:    #586e75;
+$base00:    #657b83;
+$base0:     #839496;
+$base1:     #93a1a1;
+$base2:     #eee8d5;
+$base3:     #fdf6e3;
+
+$yellow:    #b58900;
+$orange:    #cb4b16;
+$red:       #dc322f;
+$magenta:   #d33682;
+$violet:    #6c71c4;
+$blue:      #268bd2;
+$cyan:      #2aa198;
+$green:     #859900;
+
+/* Base Layout */
+body {
+  background-color: $base3;
+  color: $base00;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+/* Typography Hierarchy */
+h1, h2, h3, h4, h5, h6 {
+  color: $base01;
+  font-weight: 600;
+  line-height: 1.3;
+  margin-top: 1.5em;
+  margin-bottom: 0.5em;
+}
+
+h1 {
+  font-size: 2em;
+  border-bottom: 2px solid $base2;
+  padding-bottom: 0.3em;
+}
+
+h2 {
+  font-size: 1.5em;
+  border-bottom: 1px solid $base2;
+  padding-bottom: 0.3em;
+}
+
+h3 {
+  font-size: 1.25em;
+}
+
+/* Links - The Most Important Element */
+a {
+  color: $blue;
+  text-decoration: underline;
+  text-decoration-color: rgba($blue, 0.3);
+  text-underline-offset: 2px;
+  transition: all 0.15s ease;
+}
+
+a:hover {
+  color: $cyan;
+  text-decoration-color: rgba($cyan, 0.6);
+}
+
+a:visited {
+  color: $violet;
+  text-decoration-color: rgba($violet, 0.3);
+}
+
+a:visited:hover {
+  color: $magenta;
+  text-decoration-color: rgba($magenta, 0.6);
+}
+
+/* Lists - Primary Content Container */
+ul, ol {
+  line-height: 1.8;
+  margin-left: 1.5em;
+}
+
+li {
+  margin-bottom: 0.4em;
+}
+
+/* Strong emphasis in list items (dates, sources) */
+strong {
+  color: $base01;
+  font-weight: 600;
+}
+
+/* Code and Technical Elements */
+code {
+  background-color: $base2;
+  color: $base01;
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.9em;
+}
+
+pre {
+  background-color: $base2;
+  border: 1px solid $base1;
+  border-radius: 5px;
+  padding: 1em;
+  overflow-x: auto;
+}
+
+pre code {
+  background-color: transparent;
+  padding: 0;
+}
+
+/* Tables - For Wrapped Stats */
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 1.5em 0;
+  background-color: $base3;
+}
+
+th {
+  background-color: $base2;
+  color: $base01;
+  font-weight: 600;
+  padding: 0.75em 1em;
+  text-align: left;
+  border: 1px solid $base1;
+}
+
+td {
+  padding: 0.6em 1em;
+  border: 1px solid $base1;
+  color: $base00;
+}
+
+tr:nth-child(even) {
+  background-color: rgba($base2, 0.3);
+}
+
+tr:hover {
+  background-color: rgba($base2, 0.6);
+}
+
+/* Blockquotes */
+blockquote {
+  border-left: 4px solid $blue;
+  padding-left: 1em;
+  margin-left: 0;
+  color: $base0;
+  font-style: italic;
+}
+
+/* Horizontal Rules */
+hr {
+  border: 0;
+  border-top: 2px solid $base2;
+  margin: 2em 0;
+}
+
+/* Header/Site Title */
+.site-header {
+  background-color: $base2;
+  border-bottom: 2px solid $base1;
+}
+
+.site-title {
+  color: $base01 !important;
+  font-weight: 600;
+  text-decoration: none !important;
+}
+
+.site-title:hover {
+  color: $blue !important;
+}
+
+.site-nav .page-link {
+  color: $base00;
+  text-decoration: none;
+}
+
+.site-nav .page-link:hover {
+  color: $blue;
+  text-decoration: underline;
+}
+
+/* Footer */
+.site-footer {
+  background-color: $base2;
+  border-top: 2px solid $base1;
+  color: $base0;
+  margin-top: 3em;
+}
+
+/* Content wrapper */
+.wrapper {
+  max-width: 900px;
+}
+
+/* Special styling for Wrapped pages (emoji support) */
+.page-content h1:has(span),
+.page-content h2:has(span) {
+  color: $base01;
+}
+
+/* Emphasis for italic text */
+em {
+  color: $base01;
+  font-style: italic;
+}
+
+/* Make visited links in lists easier to track */
+li a:visited {
+  opacity: 0.8;
+}
+
+/* Focus states for accessibility */
+a:focus,
+button:focus {
+  outline: 2px solid $blue;
+  outline-offset: 2px;
+}
+
+/* Selection color */
+::selection {
+  background-color: $base2;
+  color: $base01;
+}


### PR DESCRIPTION
Replaces default Jekyll styling with custom Solarized Light design. Focus on readability, technical aesthetic, and link-centric presentation.

- Base theme: minima (clean foundation)
- Color scheme: Solarized Light palette
- Typography: System fonts, generous line-height
- No animations or images per design requirements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Resolves #12 